### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: push
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on: push
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/etianen/radiopi/security/code-scanning/1](https://github.com/etianen/radiopi/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to access the repository's code and `id-token: write` for the Codecov action to authenticate securely. No other permissions appear necessary.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
